### PR TITLE
Dev schema model

### DIFF
--- a/app.php
+++ b/app.php
@@ -1,6 +1,17 @@
 <?php
-@include_once 'vendor/autoload.php';
-require_once 'tdz.php';
-chdir(dirname(__FILE__));
-$memkey=(file_exists('.appkey')) ?\tdz::slug(file_get_contents('.appkey')) :'app';
-tdz::app('app.yml', $memkey, 'dev')->run();
+
+/**
+ * This makes our life easier when dealing with paths. Everything is relative
+ * to the application root now.
+ */
+chdir(__DIR__);
+
+require 'vendor/autoload.php';
+
+/**
+ * @todo create a decent init to avoid constants creation
+ */
+require 'tdz.php';
+
+$appMemoryNamespace = file_exists('.appkey') ? \tdz::slug(file_get_contents('.appkey')) : 'app';
+tdz::app('app.yml', $appMemoryNamespace, 'dev')->run();

--- a/composer.json
+++ b/composer.json
@@ -1,45 +1,48 @@
 {
-    "name": "capile/tecnodesign",
-    "description": "PHP Framework",
-    "type": "library",
-    "license": "GPL-3.0-only",
-    "require": {
-        "php": ">=5.6",
-        "erusev/parsedown": "^1.7.1",
-        "leafo/lessphp": "^0.5.0",
-        "leafo/scssphp": "^0.7.7",
-        "matthiasmullie/minify": "^1.3.61",
-        "phpoffice/phpspreadsheet": "^1.6.0",
-        "swiftmailer/swiftmailer": "^5.4.12",
-        "mustangostang/spyc": "^0.6.2",
-        "foxy/foxy": "^1.0.0",
-        "ext-dom": "*",
-        "ext-mbstring": "*"
-    },
-    "extra": {
-        "foxy": true
-    },
-    "autoload" : {
-        "psr-0": {
-            "" : "src/"
-        }
-    },
-    "autoload-dev" : {
-        "psr-4": {
-            "TecnodesignTest\\" : "test/src"
-        }
-    },
-    "require-dev": {
-        "league/html-to-markdown": "4.8.*",
-        "ext-yaml": "*"
-    },
-    "scripts": {
-        "test": "vendor/bin/phpunit --configuration=test/phpunit.xml"
-    },
-    "suggest" : {
-        "geshi/geshi": "Allows syntax highlight in markdown text",
-        "setasign/fpdi-tcpdf": "Allows PDF parsing and composition",
-        "mustangostang/spyc" : "Allows YAML processing when native support is not available",
-        "ext-yaml": "Needed to YAML processing natively"
+  "name": "capile/tecnodesign",
+  "description": "PHP Framework",
+  "type": "library",
+  "license": "GPL-3.0-only",
+  "require": {
+    "php": ">=5.6",
+    "erusev/parsedown": "^1.7.1",
+    "leafo/lessphp": "^0.5.0",
+    "leafo/scssphp": "^0.7.7",
+    "matthiasmullie/minify": "^1.3.61",
+    "phpoffice/phpspreadsheet": "^1.6.0",
+    "swiftmailer/swiftmailer": "^5.4.12",
+    "mustangostang/spyc": "^0.6.2",
+    "foxy/foxy": "^1.0.0",
+    "ext-dom": "*",
+    "ext-mbstring": "*",
+    "ext-zlib": "*"
+  },
+  "extra": {
+    "foxy": true
+  },
+  "autoload": {
+    "psr-0": {
+      "": "src/"
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "TecnodesignUnitTest\\": "tests/unit",
+      "TecnodesignAcceptanceTest\\": "tests/acceptance",
+      "TecnodesignApiTest\\": "tests/api"
+    }
+  },
+  "require-dev": {
+    "league/html-to-markdown": "4.8.*",
+    "ext-yaml": "*"
+  },
+  "scripts": {
+    "test": "vendor/bin/phpunit --configuration=test/phpunit.xml"
+  },
+  "suggest": {
+    "geshi/geshi": "Allows syntax highlight in markdown text",
+    "setasign/fpdi-tcpdf": "Allows PDF parsing and composition",
+    "mustangostang/spyc": "Allows YAML processing when native support is not available",
+    "ext-yaml": "Needed to YAML processing natively"
+  }
 }

--- a/src/Tecnodesign/App.php
+++ b/src/Tecnodesign/App.php
@@ -320,9 +320,10 @@ class Tecnodesign_App
         if(!self::$_request['shell']) {
             if(!headers_sent()) {
                 if(!isset(self::$_response['headers']['content-length'])) {
-                    if (isset($_SERVER['HTTP_ACCEPT_ENCODING']) && substr_count($_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip')) {
+                    if (PHP_SAPI !== 'cli-server'
+                        && isset($_SERVER['HTTP_ACCEPT_ENCODING']) && substr_count($_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip')) {
                         self::$result = gzencode(self::$result, 9);
-                        self::$_response['headers']['content-encoding'] = (strpos($_SERVER['HTTP_ACCEPT_ENCODING'], 'x-gzip'))?('x-gzip'):('gzip');
+                        self::$_response['headers']['content-encoding'] = strpos($_SERVER['HTTP_ACCEPT_ENCODING'], 'x-gzip') ? 'x-gzip' : 'gzip';
                     }
                     self::$_response['headers']['content-length'] = strlen(self::$result);
                 }

--- a/src/Tecnodesign/App.php
+++ b/src/Tecnodesign/App.php
@@ -471,7 +471,7 @@ class Tecnodesign_App
      * Currently they are loaded from TDZ_ROOT/src/Tecnodesign/Resources/assets but this should be evolved to a modular structure directly under src
      * and external components should also be loaded (example: font-awesome, d3 etc)
      */
-    public function asset($component)
+    public static function asset($component)
     {
         static $loaded=array();
         if(is_null(tdz::$assetsUrl) || isset($loaded[$component])) return;

--- a/src/Tecnodesign/Model.php
+++ b/src/Tecnodesign/Model.php
@@ -2235,7 +2235,7 @@ class Tecnodesign_Model implements ArrayAccess, Iterator, Countable, Tecnodesign
             return $this->renderRelation($this->getRelation($fn, null, $scope, false, $xmlEscape), $fn, $fd, $xmlEscape);
         }
         if($xmlEscape) {
-            if(!is_int($v) && !is_float($v)) { 
+            if(!is_int($v) && !is_float($v)) {
                 $v = str_replace(array('  ', "\n"), array('&#160; ', '<br />'), tdz::xml($v));
             }
         }
@@ -2553,7 +2553,12 @@ class Tecnodesign_Model implements ArrayAccess, Iterator, Countable, Tecnodesign
         if(isset(static::$schema['columns'][$name]) && !array_key_exists($name, $this->_original)) {
             $this->_original[$name] = $this->$name;
         }
-        @list($firstName,$ref)=explode('.', $name, 2);
+        if (strpos($name, '.') !== false) {
+            list($firstName, $ref) = explode('.', $name, 2);
+        } else {
+            $firstName = $name;
+            $ref = null;
+        }
 
         if (method_exists($this, $m='set'.$mn)) {
             $this->$m($value);

--- a/src/Tecnodesign/Resources/templates/layout.php
+++ b/src/Tecnodesign/Resources/templates/layout.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Tecnodesign default layout
  *
@@ -27,7 +27,7 @@ if(isset($script)) {
         $js .= tdz::minify($script);
     }
 	$nonce = base64_encode(openssl_random_pseudo_bytes(10));
-	header("Content-Security-Policy: default-src 'none'; style-src 'self' 'unsafe-inline' https:; img-src 'self' https: data:; font-src 'self'; script-src 'nonce-{$nonce}' 'strict-dynamic' 'self'; form-action 'self'; media-src 'self'; connect-src 'self'; object-src 'none'; frame-src https:; frame-ancestors 'none'; base-uri 'self'");
+	header("Content-Security-Policy: default-src 'none'; style-src 'self' 'unsafe-inline' https:; img-src 'self' https: data:; font-src 'self' data:; script-src 'nonce-{$nonce}' 'strict-dynamic' 'self'; form-action 'self'; media-src 'self'; connect-src 'self'; object-src 'none'; frame-src https:; frame-ancestors 'none'; base-uri 'self'");
 	$js = str_replace('<script', '<script nonce="'.$nonce.'"', $js);
     $script = $js;
     //unset($js);
@@ -46,7 +46,7 @@ if(isset($style)) {
     if($style) {
         $css .= tdz::minify($style);
     }
-    $style = $css; 
+    $style = $css;
     unset($css);
 }
 

--- a/src/Tecnodesign/User/Host.php
+++ b/src/Tecnodesign/User/Host.php
@@ -51,7 +51,7 @@ class Tecnodesign_User_Host extends Tecnodesign_PublicObject
         return self::authenticate();
     }
 
-    public function find($id)
+    public static function find($id)
     {
         if($r=self::authenticate()) {
             if(isset(Tecnodesign_User::$cfg['ns']['host']['className'])) {

--- a/tests/acceptance/StudioCest.php
+++ b/tests/acceptance/StudioCest.php
@@ -1,15 +1,20 @@
 <?php
 
-class StudioCest 
+namespace TecnodesignAcceptanceTest;
+
+
+class StudioCest
 {
     public function docsPageWorks(AcceptanceTester $I)
     {
-    	// remove cached css and see if it was properly generated
-    	$css = TDZ_DOCUMENT_ROOT.'/_/docs.css';
-    	if(file_exists($css)) unlink($css);
+        // remove cached css and see if it was properly generated
+        $css = TDZ_DOCUMENT_ROOT . '/_/docs.css';
+        if (file_exists($css)) {
+            unlink($css);
+        }
 
         $I->amOnPage('/docs/');
-        $I->see('Tecnodesign Application Development Framework');  
+        $I->see('Tecnodesign Application Development Framework');
         $I->seeElement('link[href^="/_/docs.css?"]');
     }
 }

--- a/tests/api/UserHostAuthenticationCest.php
+++ b/tests/api/UserHostAuthenticationCest.php
@@ -1,4 +1,6 @@
-<?php 
+<?php
+
+namespace TecnodesignApiTest;
 
 class UserHostAuthenticationCest
 {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,3 +10,4 @@ require 'vendor/autoload.php';
  * @todo create a decent init to avoid constants creation
  */
 require 'tdz.php';
+

--- a/tests/unit/MailTest.php
+++ b/tests/unit/MailTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TecnodesignTest;
+namespace TecnodesignUnitTest;
 
 class MailTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/unit/SpreadsheetTest.php
+++ b/tests/unit/SpreadsheetTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TecnodesignTest;
+namespace TecnodesignUnitTest;
 
 class SpreadsheetTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/unit/YamlTest.php
+++ b/tests/unit/YamlTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TecnodesignTest;
+namespace TecnodesignUnitTest;
 
 use Tecnodesign_Yaml;
 


### PR DESCRIPTION
Warning fixes:

- PHP Deprecated:  Non-static method Tecnodesign_App::asset() should not be called statically in src/Tecnodesign/Studio/Entry.php on line 293

- PHP Notice: Undefined offset: 1 in src/Tecnodesign/Model.php on line 2556

- PHP Deprecated:  Non-static method Tecnodesign_User_Host::find() should not be called statically in src/Tecnodesign/User.php on line 342

- CSP font-src warning

- App: fixes the gzip encoding witch breaks when using the internal PHP built-in server and an actual Browser that accepts gzip encoding. Codeception browser does not accept gzip encoding.

Tests: namespace configuration review
